### PR TITLE
Add callback_execution_timeout config for deadline callbacks

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -3026,6 +3026,20 @@ state_store:
       example: "mypackage.state.CustomStateBackend"
       default: "airflow.state.metastore.MetastoreStateBackend"
 
+deadlines:
+  description: |
+    Configuration for deadline alerts feature.
+  options:
+    callback_execution_timeout:
+      description: |
+        Maximum time in seconds that a deadline callback is allowed to execute before being
+        terminated. If a callback does not complete within this timeout, the supervisor will
+        kill the subprocess. Set to 0 to disable the timeout (callbacks may run indefinitely).
+      version_added: 3.3.0
+      type: integer
+      example: ~
+      default: "300"
+
 profiling:
   description: |
     Configuration for memory profiling in Airflow component.

--- a/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import signal
 import sys
 import time
 from importlib import import_module
@@ -29,6 +30,7 @@ import structlog
 from pydantic import Field, TypeAdapter
 
 from airflow.sdk._shared.module_loading import accepts_context, accepts_keyword_args
+from airflow.sdk.configuration import conf
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
     ErrorResponse,
@@ -66,6 +68,10 @@ if TYPE_CHECKING:
 __all__ = ["CallbackSubprocess", "supervise_callback"]
 
 log: FilteringBoundLogger = structlog.get_logger(logger_name="callback_supervisor")
+
+# Maximum time (in seconds) a deadline callback is allowed to run before being killed.
+# A value of 0 disables the timeout.
+CALLBACK_EXECUTION_TIMEOUT: int = conf.getint("deadlines", "callback_execution_timeout", fallback=300)
 
 
 # The set of messages that a callback subprocess can send to the supervisor.
@@ -246,13 +252,29 @@ class CallbackSubprocess(WatchedSubprocess):
 
     def _monitor_subprocess(self):
         """
-        Monitor the subprocess until it exits.
+        Monitor the subprocess until it exits or exceeds the callback execution timeout.
 
-        A simplified version of ActivitySubprocess._monitor_subprocess() without heartbeating
-        or timeout handling, just process output monitoring and stuck-socket cleanup.
+        Enforces the ``[deadlines] callback_execution_timeout`` configuration: if the
+        subprocess runs longer than the configured limit, it is killed with SIGTERM
+        (escalating to SIGKILL if necessary).
         """
+        start_monotonic = time.monotonic()
+
         while self._exit_code is None or self._open_sockets:
             self._service_subprocess(max_wait_time=MIN_HEARTBEAT_INTERVAL)
+
+            # Enforce callback execution timeout (0 means disabled).
+            if (
+                CALLBACK_EXECUTION_TIMEOUT > 0
+                and self._exit_code is None
+                and (time.monotonic() - start_monotonic) > CALLBACK_EXECUTION_TIMEOUT
+            ):
+                log.warning(
+                    "Callback execution timeout reached; terminating subprocess",
+                    pid=self.pid,
+                    timeout_seconds=CALLBACK_EXECUTION_TIMEOUT,
+                )
+                self.kill(signal.SIGTERM, force=True)
 
             # If the process has exited but sockets remain open, apply a timeout
             # to prevent hanging indefinitely on stuck sockets.

--- a/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
@@ -282,7 +282,7 @@ class TestCallbackExecutionTimeout:
                 proc._exit_code = -signal.SIGTERM
             return None
 
-        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+        mocker.patch.object(CallbackSubprocess, "_service_subprocess", side_effect=mock_service_subprocess)
 
         with patch(
             "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic
@@ -321,7 +321,7 @@ class TestCallbackExecutionTimeout:
                 proc._exit_code = 0
             return None
 
-        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+        mocker.patch.object(CallbackSubprocess, "_service_subprocess", side_effect=mock_service_subprocess)
 
         with patch(
             "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic

--- a/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import signal
 import socket
 from dataclasses import dataclass
 from operator import attrgetter
@@ -228,3 +229,104 @@ class TestCallbackHandleRequest:
 
         if client_mock:
             mock_client_method.assert_called_once_with(*client_mock.args, **client_mock.kwargs)
+
+
+class TestCallbackExecutionTimeout:
+    """Verify that CallbackSubprocess kills the subprocess when the execution timeout is exceeded."""
+
+    @pytest.fixture
+    def callback_subprocess(self, mocker):
+        read_end, write_end = socket.socketpair()
+        proc = CallbackSubprocess(
+            process_log=mocker.MagicMock(),
+            id="12345678-1234-5678-1234-567812345678",
+            pid=12345,
+            stdin=write_end,
+            client=mocker.Mock(),
+            process=mocker.Mock(),
+        )
+        return proc, read_end
+
+    def test_timeout_kills_subprocess(self, monkeypatch, mocker, callback_subprocess, captured_logs):
+        """When the callback exceeds the configured timeout, the subprocess is terminated."""
+        timeout_seconds = 10
+        monkeypatch.setattr(
+            "airflow.sdk.execution_time.callback_supervisor.CALLBACK_EXECUTION_TIMEOUT", timeout_seconds
+        )
+
+        proc, _read_end = callback_subprocess
+
+        # Patch the kill method so we can assert it was called
+        mock_kill = mocker.patch("airflow.sdk.execution_time.callback_supervisor.CallbackSubprocess.kill")
+
+        # Simulate time progressing past the timeout.
+        # First call returns 0 (start), subsequent calls return past-timeout values.
+        call_count = 0
+
+        def mock_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return 0.0
+            # After the first call, time has exceeded the timeout
+            return timeout_seconds + 1.0
+
+        # Patch _service_subprocess to simulate one loop iteration where the process is still alive
+        service_call_count = 0
+
+        def mock_service_subprocess(max_wait_time):
+            nonlocal service_call_count
+            service_call_count += 1
+            # After the kill is called (which sets _exit_code via the mock), stop the loop
+            if service_call_count > 1:
+                proc._exit_code = -signal.SIGTERM
+            return None
+
+        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+
+        with patch(
+            "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic
+        ):
+            proc._monitor_subprocess()
+
+        mock_kill.assert_called_once_with(signal.SIGTERM, force=True)
+        assert any(
+            "Callback execution timeout reached" in record.get("event", "") for record in captured_logs
+        )
+
+    def test_no_timeout_when_disabled(self, monkeypatch, mocker, callback_subprocess):
+        """When timeout is 0, the subprocess is never killed for exceeding a time limit."""
+        monkeypatch.setattr("airflow.sdk.execution_time.callback_supervisor.CALLBACK_EXECUTION_TIMEOUT", 0)
+
+        proc, _read_end = callback_subprocess
+
+        mock_kill = mocker.patch("airflow.sdk.execution_time.callback_supervisor.CallbackSubprocess.kill")
+
+        # Simulate time progressing well past any reasonable timeout
+        call_count = 0
+
+        def mock_monotonic():
+            nonlocal call_count
+            call_count += 1
+            # Return ever-increasing time (simulating long-running callback)
+            return call_count * 1000.0
+
+        # Subprocess exits normally after one iteration
+        service_call_count = 0
+
+        def mock_service_subprocess(max_wait_time):
+            nonlocal service_call_count
+            service_call_count += 1
+            if service_call_count >= 2:
+                proc._exit_code = 0
+            return None
+
+        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+
+        with patch(
+            "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic
+        ):
+            proc._monitor_subprocess()
+
+        # kill should never be called when timeout is disabled
+        mock_kill.assert_not_called()


### PR DESCRIPTION
## Summary

Deadline callbacks currently have no timeout -- if a callback hangs, it blocks the executor/triggerer indefinitely. This adds a `[deadlines] callback_execution_timeout` configuration option that enforces a maximum execution time for callback subprocesses.

- Adds a new `[deadlines]` config section with `callback_execution_timeout` (default: 300 seconds)
- Enforces the timeout in `CallbackSubprocess._monitor_subprocess()` -- kills the subprocess with SIGTERM (escalating to SIGKILL) when exceeded
- Setting `callback_execution_timeout = 0` disables the timeout entirely
- Includes unit tests verifying both the timeout enforcement and the disable behavior

Related Asana task: https://app.asana.com/0/0/1213687258219376 ("Discuss, decide, and implement if desired")

## Questions for discussion

This is a **proposal** -- opening as a draft to gather community input before finalizing:

1. **Single global config vs per-callback?** Currently this is one global `[deadlines] callback_execution_timeout` that applies to all deadline callbacks. Should individual callbacks be able to override it (e.g. via a parameter on the deadline definition)?

2. **Default value: 300s or something else?** 5 minutes feels reasonable for most notification callbacks (Slack, PagerDuty, email). Is this too aggressive for callbacks that do heavier work (e.g. creating JIRA tickets, running queries)?

3. **Should this apply to both sync (executor) and async (triggerer) callbacks?** Currently it only applies to the synchronous `CallbackSubprocess` path. The triggerer's async callback path has different execution characteristics -- should it share the same config or get its own?

4. **Config section naming:** Is `[deadlines]` the right section, or should this live under `[scheduler]` or `[workers]`?

## Test plan

- [ ] `test_timeout_kills_subprocess` -- verifies the subprocess is terminated when timeout is exceeded
- [ ] `test_no_timeout_when_disabled` -- verifies no kill when timeout is 0
- [ ] Manual: configure a callback that sleeps longer than the timeout, verify it gets killed

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes -- Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)